### PR TITLE
Update setup.py, exclude tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/iloveicedgreentea/py-madvr",
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=["tests","tests.*"]),
     package_data={"py_madvr2": ["py.typed"]},
     classifiers=[
         "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
otherwise:
```
>>> Jobs: 0 of 1 complete, 1 failed                 Load avg: 0.47, 0.38, 0.50
 * Package:    dev-python/py-madvr2-1.6.32:0
 * Repository: HomeAssistantRepository
 * Maintainer: b@edevau.net
 * USE:        abi_x86_64 amd64 elibc_glibc kernel_linux python_targets_python3_12
 * FEATURES:   network-sandbox preserve-libs sandbox userpriv usersandbox
>>> Unpacking source...
>>> Unpacking py_madvr2-1.6.32.tar.gz to /var/tmp/portage/dev-python/py-madvr2-1.6.32/work
>>> Source unpacked in /var/tmp/portage/dev-python/py-madvr2-1.6.32/work
>>> Preparing source in /var/tmp/portage/dev-python/py-madvr2-1.6.32/work/py_madvr2-1.6.32 ...
 * Build system packages:
 *   dev-python/setuptools         : 74.1.3-r1
>>> Source prepared.
>>> Configuring source in /var/tmp/portage/dev-python/py-madvr2-1.6.32/work/py_madvr2-1.6.32 ...
>>> Source configured.
>>> Compiling source in /var/tmp/portage/dev-python/py-madvr2-1.6.32/work/py_madvr2-1.6.32 ...
 * python3_12: running distutils-r1_run_phase distutils-r1_python_compile
python3.12 setup.py build -j 5
running build
running build_py
creating /var/tmp/portage/dev-python/py-madvr2-1.6.32/work/py_madvr2-1.6.32-python3_12/lib/madvr
copying madvr/notifications.py -> /var/tmp/portage/dev-python/py-madvr2-1.6.32/work/py_madvr2-1.6.32-python3_12/lib/madvr
copying madvr/__init__.py -> /var/tmp/portage/dev-python/py-madvr2-1.6.32/work/py_madvr2-1.6.32-python3_12/lib/madvr
copying madvr/wol.py -> /var/tmp/portage/dev-python/py-madvr2-1.6.32/work/py_madvr2-1.6.32-python3_12/lib/madvr
copying madvr/commands.py -> /var/tmp/portage/dev-python/py-madvr2-1.6.32/work/py_madvr2-1.6.32-python3_12/lib/madvr
copying madvr/consts.py -> /var/tmp/portage/dev-python/py-madvr2-1.6.32/work/py_madvr2-1.6.32-python3_12/lib/madvr
copying madvr/errors.py -> /var/tmp/portage/dev-python/py-madvr2-1.6.32/work/py_madvr2-1.6.32-python3_12/lib/madvr
copying madvr/madvr.py -> /var/tmp/portage/dev-python/py-madvr2-1.6.32/work/py_madvr2-1.6.32-python3_12/lib/madvr
creating /var/tmp/portage/dev-python/py-madvr2-1.6.32/work/py_madvr2-1.6.32-python3_12/lib/tests
copying tests/__init__.py -> /var/tmp/portage/dev-python/py-madvr2-1.6.32/work/py_madvr2-1.6.32-python3_12/lib/tests
copying tests/test_MadVR.py -> /var/tmp/portage/dev-python/py-madvr2-1.6.32/work/py_madvr2-1.6.32-python3_12/lib/tests
copying tests/conftest.py -> /var/tmp/portage/dev-python/py-madvr2-1.6.32/work/py_madvr2-1.6.32-python3_12/lib/tests
copying madvr/py.typed -> /var/tmp/portage/dev-python/py-madvr2-1.6.32/work/py_madvr2-1.6.32-python3_12/lib/madvr
warning: build_py: byte-compiling is disabled, skipping.

>>> Source compiled.
 * Skipping make test/check due to ebuild restriction.
>>> Test phase [disabled because of RESTRICT=test]: dev-python/py-madvr2-1.6.32

>>> Install dev-python/py-madvr2-1.6.32 into /var/tmp/portage/dev-python/py-madvr2-1.6.32/image
 * python3_12: running distutils-r1_run_phase distutils-r1_python_install
python3.12 setup.py install --skip-build --root=/var/tmp/portage/dev-python/py-madvr2-1.6.32/image/_python3.12
running install
/usr/lib/python3.12/site-packages/setuptools/_distutils/cmd.py:66: SetuptoolsDeprecationWarning: setup.py install is deprecated.
!!

        ********************************************************************************
        Please avoid running ``setup.py`` directly.
        Instead, use pypa/build, pypa/installer or other
        standards-based tools.

        See https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html for details.
        ********************************************************************************

!!
  self.initialize_options()
running install_lib
creating /var/tmp/portage/dev-python/py-madvr2-1.6.32/image/_python3.12
creating /var/tmp/portage/dev-python/py-madvr2-1.6.32/image/_python3.12/usr
creating /var/tmp/portage/dev-python/py-madvr2-1.6.32/image/_python3.12/usr/lib
creating /var/tmp/portage/dev-python/py-madvr2-1.6.32/image/_python3.12/usr/lib/python3.12
creating /var/tmp/portage/dev-python/py-madvr2-1.6.32/image/_python3.12/usr/lib/python3.12/site-packages
creating /var/tmp/portage/dev-python/py-madvr2-1.6.32/image/_python3.12/usr/lib/python3.12/site-packages/madvr
copying /var/tmp/portage/dev-python/py-madvr2-1.6.32/work/py_madvr2-1.6.32-python3_12/lib/madvr/py.typed -> /var/tmp/portage/dev-python/py-madvr2-1.6.32/image/_python3.12/usr/lib/python3.12/site-packages/madvr
copying /var/tmp/portage/dev-python/py-madvr2-1.6.32/work/py_madvr2-1.6.32-python3_12/lib/madvr/notifications.py -> /var/tmp/portage/dev-python/py-madvr2-1.6.32/image/_python3.12/usr/lib/python3.12/site-packages/madvr
copying /var/tmp/portage/dev-python/py-madvr2-1.6.32/work/py_madvr2-1.6.32-python3_12/lib/madvr/__init__.py -> /var/tmp/portage/dev-python/py-madvr2-1.6.32/image/_python3.12/usr/lib/python3.12/site-packages/madvr
copying /var/tmp/portage/dev-python/py-madvr2-1.6.32/work/py_madvr2-1.6.32-python3_12/lib/madvr/wol.py -> /var/tmp/portage/dev-python/py-madvr2-1.6.32/image/_python3.12/usr/lib/python3.12/site-packages/madvr
copying /var/tmp/portage/dev-python/py-madvr2-1.6.32/work/py_madvr2-1.6.32-python3_12/lib/madvr/commands.py -> /var/tmp/portage/dev-python/py-madvr2-1.6.32/image/_python3.12/usr/lib/python3.12/site-packages/madvr
copying /var/tmp/portage/dev-python/py-madvr2-1.6.32/work/py_madvr2-1.6.32-python3_12/lib/madvr/consts.py -> /var/tmp/portage/dev-python/py-madvr2-1.6.32/image/_python3.12/usr/lib/python3.12/site-packages/madvr
copying /var/tmp/portage/dev-python/py-madvr2-1.6.32/work/py_madvr2-1.6.32-python3_12/lib/madvr/errors.py -> /var/tmp/portage/dev-python/py-madvr2-1.6.32/image/_python3.12/usr/lib/python3.12/site-packages/madvr
copying /var/tmp/portage/dev-python/py-madvr2-1.6.32/work/py_madvr2-1.6.32-python3_12/lib/madvr/madvr.py -> /var/tmp/portage/dev-python/py-madvr2-1.6.32/image/_python3.12/usr/lib/python3.12/site-packages/madvr
creating /var/tmp/portage/dev-python/py-madvr2-1.6.32/image/_python3.12/usr/lib/python3.12/site-packages/tests
copying /var/tmp/portage/dev-python/py-madvr2-1.6.32/work/py_madvr2-1.6.32-python3_12/lib/tests/__init__.py -> /var/tmp/portage/dev-python/py-madvr2-1.6.32/image/_python3.12/usr/lib/python3.12/site-packages/tests
copying /var/tmp/portage/dev-python/py-madvr2-1.6.32/work/py_madvr2-1.6.32-python3_12/lib/tests/test_MadVR.py -> /var/tmp/portage/dev-python/py-madvr2-1.6.32/image/_python3.12/usr/lib/python3.12/site-packages/tests
copying /var/tmp/portage/dev-python/py-madvr2-1.6.32/work/py_madvr2-1.6.32-python3_12/lib/tests/conftest.py -> /var/tmp/portage/dev-python/py-madvr2-1.6.32/image/_python3.12/usr/lib/python3.12/site-packages/tests
byte-compiling /var/tmp/portage/dev-python/py-madvr2-1.6.32/image/_python3.12/usr/lib/python3.12/site-packages/madvr/notifications.py to notifications.cpython-312.pyc
byte-compiling /var/tmp/portage/dev-python/py-madvr2-1.6.32/image/_python3.12/usr/lib/python3.12/site-packages/madvr/__init__.py to __init__.cpython-312.pyc
byte-compiling /var/tmp/portage/dev-python/py-madvr2-1.6.32/image/_python3.12/usr/lib/python3.12/site-packages/madvr/wol.py to wol.cpython-312.pyc
byte-compiling /var/tmp/portage/dev-python/py-madvr2-1.6.32/image/_python3.12/usr/lib/python3.12/site-packages/madvr/commands.py to commands.cpython-312.pyc
byte-compiling /var/tmp/portage/dev-python/py-madvr2-1.6.32/image/_python3.12/usr/lib/python3.12/site-packages/madvr/consts.py to consts.cpython-312.pyc
byte-compiling /var/tmp/portage/dev-python/py-madvr2-1.6.32/image/_python3.12/usr/lib/python3.12/site-packages/madvr/errors.py to errors.cpython-312.pyc
byte-compiling /var/tmp/portage/dev-python/py-madvr2-1.6.32/image/_python3.12/usr/lib/python3.12/site-packages/madvr/madvr.py to madvr.cpython-312.pyc
byte-compiling /var/tmp/portage/dev-python/py-madvr2-1.6.32/image/_python3.12/usr/lib/python3.12/site-packages/tests/__init__.py to __init__.cpython-312.pyc
byte-compiling /var/tmp/portage/dev-python/py-madvr2-1.6.32/image/_python3.12/usr/lib/python3.12/site-packages/tests/test_MadVR.py to test_MadVR.cpython-312.pyc
byte-compiling /var/tmp/portage/dev-python/py-madvr2-1.6.32/image/_python3.12/usr/lib/python3.12/site-packages/tests/conftest.py to conftest.cpython-312.pyc
writing byte-compilation script '/var/tmp/portage/dev-python/py-madvr2-1.6.32/temp/tmp7cfys8k3.py'
/usr/bin/python3.12 /var/tmp/portage/dev-python/py-madvr2-1.6.32/temp/tmp7cfys8k3.py
removing /var/tmp/portage/dev-python/py-madvr2-1.6.32/temp/tmp7cfys8k3.py
writing byte-compilation script '/var/tmp/portage/dev-python/py-madvr2-1.6.32/temp/tmp3gkq3ajs.py'
/usr/bin/python3.12 /var/tmp/portage/dev-python/py-madvr2-1.6.32/temp/tmp3gkq3ajs.py
removing /var/tmp/portage/dev-python/py-madvr2-1.6.32/temp/tmp3gkq3ajs.py
running install_egg_info
running egg_info
writing py_madvr2.egg-info/PKG-INFO
writing dependency_links to py_madvr2.egg-info/dependency_links.txt
writing top-level names to py_madvr2.egg-info/top_level.txt
[10/26/24 22:50:55] ERROR    listing git files failed - pretending there aren't any                                                                          git.py:26
reading manifest file 'py_madvr2.egg-info/SOURCES.txt'
adding license file 'LICENSE'
writing manifest file 'py_madvr2.egg-info/SOURCES.txt'
Copying py_madvr2.egg-info to /var/tmp/portage/dev-python/py-madvr2-1.6.32/image/_python3.12/usr/lib/python3.12/site-packages/py_madvr2-1.6.32-py3.12.egg-info
running install_scripts
 * The following unexpected files/directories were found top-level
 * in the site-packages directory:
 *
 *   /usr/lib/python3.12/site-packages/tests
 *
 * This is most likely a bug in the build system.  More information
 * can be found in the Python Guide:
 * https://projects.gentoo.org/python/guide/qawarn.html#stray-top-level-files-in-site-packages
 * ERROR: dev-python/py-madvr2-1.6.32::HomeAssistantRepository failed (install phase):
 *   Failing install because of stray top-level files in site-packages
 *
 * Call stack:
 *     ebuild.sh, line  136:  Called src_install
 *   environment, line 4039:  Called distutils-r1_src_install
 *   environment, line 1979:  Called _distutils-r1_run_foreach_impl 'distutils-r1_python_install'
 *   environment, line  743:  Called python_foreach_impl 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 3649:  Called multibuild_foreach_variant '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 3145:  Called _multibuild_run '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 3143:  Called _python_multibuild_wrapper 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 1235:  Called distutils-r1_run_phase 'distutils-r1_python_install'
 *   environment, line 1942:  Called _distutils-r1_post_python_install
 *   environment, line  635:  Called die
 * The specific snippet of code:
 *               die "Failing install because of stray top-level files in site-packages";
 *
 * If you need support, post the output of `emerge --info '=dev-python/py-madvr2-1.6.32::HomeAssistantRepository'`,
 * the complete build log and the output of `emerge -pqv '=dev-python/py-madvr2-1.6.32::HomeAssistantRepository'`.
 * The complete build log is located at '/var/tmp/portage/dev-python/py-madvr2-1.6.32/temp/build.log'.
 * The ebuild environment file is located at '/var/tmp/portage/dev-python/py-madvr2-1.6.32/temp/environment'.
 * Working directory: '/var/tmp/portage/dev-python/py-madvr2-1.6.32/work/py_madvr2-1.6.32'
 * S: '/var/tmp/portage/dev-python/py-madvr2-1.6.32/work/py_madvr2-1.6.32'

 * Messages for package dev-python/py-madvr2-1.6.32:

 * The following unexpected files/directories were found top-level
 * in the site-packages directory:
 *
 *   /usr/lib/python3.12/site-packages/tests
 *
 * This is most likely a bug in the build system.  More information
 * can be found in the Python Guide:
 * https://projects.gentoo.org/python/guide/qawarn.html#stray-top-level-files-in-site-packages

```